### PR TITLE
Resolving error that occurred when the program writes text file output

### DIFF
--- a/SPIR/Main.py
+++ b/SPIR/Main.py
@@ -222,10 +222,9 @@ if (args.output):
         f.write(header)
     
     for rep in range(replication):
-        for rows in num[rep]:
-            for row in rows:
-                line = str(rep) + outputSep + str(row[0]) + outputSep + str(row[1]) + outputSep + str(row[2]) + outputSep + str(row[3]) + outputSep + str(row[4]) + "\n"
-                f.write(line)
+        for row in num[rep]:
+            line = str(rep) + outputSep + str(row[0]) + outputSep + str(row[1]) + outputSep + str(row[2]) + outputSep + str(row[3]) + outputSep + str(row[4]) + "\n"
+            f.write(line)
     f.close()
 
 ##


### PR DESCRIPTION
 When the program attempted to write text file output, Python would throw the following error:

>   File "SPIR/SPIR/Main.py", line 227, in <module>
>     line = str(rep) + outputSep + str(row[0]) + outputSep + str(row[1]) + outputSep + str(row[2]) + outputSep + str(row[3]) + outputSep + str(row[4]) + "\n"
> TypeError: 'int' object is not subscriptable

This was caused by trying to access "row" as an array when it's really an integer.  I adjusted the for loop to make "row" an array, and now the output file will be written correctly.
